### PR TITLE
Add calculations for trailer and end record values in 入出金取引明細1 and 総合…

### DIFF
--- a/Diva.Zengin/Formats/入出金取引明細1.cs
+++ b/Diva.Zengin/Formats/入出金取引明細1.cs
@@ -10,17 +10,27 @@ public class 入出金取引明細1 : ISequence<入出金取引明細Header, 入
     public 入出金取引明細Trailer Trailer { get; set; } = new();
     public 入出金取引明細End End { get; set; } = new();
 
+    /// <summary>
+    /// トレーラー・レコードの項目を設定します。
+    /// </summary>
+    /// <remarks>貸越区分、取引後残高は設定されない。</remarks>
     public void SetTrailerValues()
     {
         Trailer.データ区分 = データ区分.Trailer;
         Trailer.データレコード件数 = DataList.Count;
-        // TODO: 各項目の計算
+        Trailer.入金件数 = DataList.Count(x => x.入払区分 == 1);
+        Trailer.入金額合計 = DataList.Where(x => x.入払区分 == 1).Sum(x => x.取引金額);
+        Trailer.出金件数 = DataList.Count(x => x.入払区分 == 2);
+        Trailer.出金額合計 = DataList.Where(x => x.入払区分 == 2).Sum(x => x.取引金額);
     }
 
+    /// <summary>
+    /// エンド・レコードの項目を設定します。
+    /// </summary>
+    /// <remarks>口座数は設定されない</remarks>
     public void SetEndValues()
     {
         End.データ区分 = データ区分.End;
-        End.レコード総件数 = DataList.Count;
-        // TODO: 各項目の計算
+        End.レコード総件数 = DataList.Count + 3;
     }
 }

--- a/Diva.Zengin/Formats/総合振込.cs
+++ b/Diva.Zengin/Formats/総合振込.cs
@@ -6,14 +6,21 @@ public class 総合振込 : ISequence<総合振込Header, 総合振込Data, 総�
     public List<総合振込Data> DataList { get; set; } = [];
     public 総合振込Trailer Trailer { get; set; } = new();
     public 総合振込End End { get; set; } = new();
-    
+
+    /// <summary>
+    /// トレーラー・レコードの項目を設定します。
+    /// </summary>
     public void SetTrailerValues()
     {
         Trailer.データ区分 = データ区分.Trailer;
         Trailer.合計件数 = DataList.Count;
-        // TODO: 各項目の計算
+        Trailer.合計金額 = DataList.Sum(x => x.振込金額);
     }
 
+    /// <summary>
+    /// エンド・レコードの項目を設定します。
+    /// </summary>
+    /// <remarks>エンド・レコードはダミーのみ</remarks>
     public void SetEndValues()
     {
         End.データ区分 = データ区分.End;


### PR DESCRIPTION

This pull request includes changes to the `Diva.Zengin` project, specifically to improve the implementation of trailer and end record value setting methods in two classes. The changes add detailed comments and implement the calculation of several fields that were previously marked as TODO.

Improvements to trailer and end record value setting:

* [`Diva.Zengin/Formats/入出金取引明細1.cs`](diffhunk://#diff-0f8b0ead130db2394b1e73c75134707fd1db4e634e15b90c2bfae6f991b19cf9R13-R34): Added comments to `SetTrailerValues` and `SetEndValues` methods, and implemented the calculation of `入金件数`, `入金額合計`, `出金件数`, and `出金額合計` in `SetTrailerValues`. Additionally, updated the calculation of `レコード総件数` in `SetEndValues`.
* [`Diva.Zengin/Formats/総合振込.cs`](diffhunk://#diff-f7ca262beb072abdec8166bfe673f2711cd5b917c844be629e2fbaf6b78464b7R10-R23): Added comments to `SetTrailerValues` and `SetEndValues` methods, and implemented the calculation of `合計金額` in `SetTrailerValues`.