### PR TITLE
Enable nullable reference types and update ZenginReaderTest to includ…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore
+
+      - name: Run tests
+        run: dotnet test --no-build --verbosity normal

--- a/Diva.Zengin.Tests/Converters/CharacterConverterTest.cs
+++ b/Diva.Zengin.Tests/Converters/CharacterConverterTest.cs
@@ -1,0 +1,37 @@
+using Diva.Zengin.Converters;
+using JetBrains.Annotations;
+using Xunit;
+
+namespace Diva.Zengin.Tests.Converters;
+
+[TestSubject(typeof(CharacterConverter))]
+public class CharacterConverterTest
+{
+    [Theory]
+    [InlineData("test", "test")]
+    [InlineData("test  ", "test")]
+    [InlineData("", "", false)]
+    [InlineData("", null, true)]
+    [InlineData(null, "", false)]
+    [InlineData(null, null, true)]
+    [InlineData("   ", "", false)]
+    [InlineData("   ", null, true)]
+    public void ConvertFromString_HandlesVariousInputs(string? input, string? expected, bool nullable = false)
+    {
+        var result = CharacterConverter.ConvertFromString(input, nullable);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("test", 4, "test")]
+    [InlineData("test", 6, "test  ")]
+    [InlineData("test", 2, "test")] // Note: This will truncate as PadRight doesn't shrink
+    [InlineData("", 3, "   ")]
+    [InlineData(null, 3, "   ")]
+    [InlineData(123, 5, "123  ")]
+    public void ConvertToString_HandlesVariousInputs(object? input, int count, string expected)
+    {
+        var result = CharacterConverter.ConvertToString(input, count);
+        Assert.Equal(expected, result);
+    }
+}

--- a/Diva.Zengin.Tests/Converters/NumberConverterTest.cs
+++ b/Diva.Zengin.Tests/Converters/NumberConverterTest.cs
@@ -1,0 +1,73 @@
+using Diva.Zengin.Converters;
+using JetBrains.Annotations;
+using Xunit;
+
+namespace Diva.Zengin.Tests.Converters;
+
+[TestSubject(typeof(NumberConverter))]
+public class NumberConverterTest
+{
+    private enum TestEnum
+    {
+        One = 1,
+        Two = 2,
+        Three = 3
+    }
+
+    [Fact]
+    public void ConvertFromString_NullOrEmptyString_ReturnsDefault()
+    {
+        Assert.Null(NumberConverter.ConvertFromString<int?>(null));
+        Assert.Null(NumberConverter.ConvertFromString<int?>(string.Empty));
+        Assert.Null(NumberConverter.ConvertFromString<int?>("   "));
+    }
+
+    [Fact]
+    public void ConvertFromString_ValidInteger_ReturnsCorrectValue()
+    {
+        Assert.Equal(123, NumberConverter.ConvertFromString<int>("123"));
+        Assert.Equal(123, NumberConverter.ConvertFromString<int?>("123"));
+    }
+
+    [Fact]
+    public void ConvertFromString_ValidDecimal_ReturnsCorrectValue()
+    {
+        Assert.Equal(12345m, NumberConverter.ConvertFromString<decimal>("12345"));
+        Assert.Equal(12345m, NumberConverter.ConvertFromString<decimal?>("12345"));
+    }
+
+    [Fact]
+    public void ConvertFromString_EnumByNumber_ReturnsCorrectEnum()
+    {
+        Assert.Equal(TestEnum.Two, NumberConverter.ConvertFromString<TestEnum>("2"));
+        Assert.Equal(TestEnum.Three, NumberConverter.ConvertFromString<TestEnum>("003"));
+    }
+
+    [Fact]
+    public void ConvertToString_NullValue_ReturnsSpaces()
+    {
+        Assert.Equal("   ", NumberConverter.ConvertToString(null, 3));
+        Assert.Equal("     ", NumberConverter.ConvertToString(null, 5));
+    }
+
+    [Fact]
+    public void ConvertToString_EnumValue_ReturnsNumberWithPadding()
+    {
+        Assert.Equal("01", NumberConverter.ConvertToString(TestEnum.One, 2));
+        Assert.Equal("002", NumberConverter.ConvertToString(TestEnum.Two, 3));
+    }
+
+    [Fact]
+    public void ConvertToString_DecimalValue_ReturnsFormattedString()
+    {
+        Assert.Equal("123", NumberConverter.ConvertToString(123m, 3));
+        Assert.Equal("0123", NumberConverter.ConvertToString(123m, 4));
+    }
+
+    [Fact]
+    public void ConvertToString_IntegerValue_ReturnsFormattedString()
+    {
+        Assert.Equal("123", NumberConverter.ConvertToString(123, 3));
+        Assert.Equal("0456", NumberConverter.ConvertToString(456, 4));
+    }
+}

--- a/Diva.Zengin.Tests/Diva.Zengin.Tests.csproj
+++ b/Diva.Zengin.Tests/Diva.Zengin.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>net9.0</TargetFrameworks>
     
     <IsPackable>false</IsPackable>
+    
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Diva.Zengin.Tests/Diva.Zengin.Tests.csproj
+++ b/Diva.Zengin.Tests/Diva.Zengin.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Bogus" Version="35.6.2" />
     <PackageReference Include="JetBrains.Annotations" Version="2025.1.0-eap1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/Diva.Zengin.Tests/Generator.cs
+++ b/Diva.Zengin.Tests/Generator.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Bogus;
+using Diva.Zengin.Formats;
+
+namespace Diva.Zengin.Tests;
+
+public static class Generator
+{
+    private static DateOnly ToDateOnly(this DateTime dateTime) => DateOnly.FromDateTime(dateTime);
+
+    public static 振込入金通知A GenerateRandom振込入金通知A()
+    {
+        var headerFaker = new Faker<振込入金通知Header>()
+            .RuleFor(x => x.種別コード, f => 1)
+            .RuleFor(x => x.コード区分, f => 0)
+            .RuleFor(x => x.作成日, f => f.Date.Past().ToDateOnly())
+            .RuleFor(x => x.勘定日開始, f => f.Date.Past().ToDateOnly())
+            .RuleFor(x => x.勘定日終了, f => f.Date.Past().ToDateOnly())
+            .RuleFor(x => x.銀行コード, f => f.Random.Int(0, 9999))
+            .RuleFor(x => x.銀行名, f => f.Random.String2(1, 15))
+            .RuleFor(x => x.支店コード, f => f.Random.Int(0, 999))
+            .RuleFor(x => x.支店名, f => f.Random.String2(1, 15))
+            .RuleFor(x => x.預金種目, f => f.Random.Int(0, 9))
+            .RuleFor(x => x.口座番号, f => f.Random.Int(0, 9999999))
+            .RuleFor(x => x.口座名, f => f.Random.String2(1, 40))
+            .RuleFor(x => x.ダミー, f => new string(' ', 93));
+
+        var dataFaker = new Faker<振込入金通知DataA>()
+            .RuleFor(x => x.照会番号, f => f.Random.Int(0, 999999))
+            .RuleFor(x => x.勘定日, f => f.Date.Past().ToDateOnly())
+            .RuleFor(x => x.起算日, f => f.Date.Past().ToDateOnly())
+            .RuleFor(x => x.金額, f => f.Random.Long(0, 9999999999))
+            .RuleFor(x => x.うち他店券金額, f => f.Random.Long(0, 9999999999))
+            .RuleFor(x => x.振込依頼人コード, f => f.Random.Long(0, 9999999999))
+            .RuleFor(x => x.振込依頼人名, f => f.Random.String2(1, 48))
+            .RuleFor(x => x.仕向銀行名, f => f.Random.String2(1, 15))
+            .RuleFor(x => x.仕向店名, f => f.Random.String2(1, 15))
+            .RuleFor(x => x.取消区分, f => f.Random.Int(0, 9))
+            .RuleFor(x => x.EDI情報, f => f.Random.String2(1, 20))
+            .RuleFor(x => x.ダミー, f => new string(' ', 52));
+
+        var trailerFaker = new Faker<振込入金通知Trailer>()
+            .RuleFor(x => x.データ区分, f => データ区分.Trailer)
+            .RuleFor(x => x.振込合計件数, f => f.Random.Int(0, 999999))
+            .RuleFor(x => x.振込合計金額, f => f.Random.Long(0, 999999999999))
+            .RuleFor(x => x.取消合計件数, f => f.Random.Int(0, 999999))
+            .RuleFor(x => x.取消合計金額, f => f.Random.Long(0, 999999999999))
+            .RuleFor(x => x.ダミー, f => new string(' ', 163));
+
+        var endFaker = new Faker<振込入金通知End>()
+            .RuleFor(x => x.データ区分, f => データ区分.End)
+            .RuleFor(x => x.ダミー, f => new string(' ', 199));
+
+        var 振込入金通知A = new 振込入金通知A
+        {
+            Header = headerFaker.Generate(),
+            DataList = dataFaker.Generate(10), // Generate multiple DataList items
+            Trailer = trailerFaker.Generate(),
+            End = endFaker.Generate()
+        };
+
+        return 振込入金通知A;
+    }
+
+    public static 入出金取引明細1 GenerateRandom入出金取引明細1()
+    {
+        var headerFaker = new Faker<入出金取引明細Header>()
+            .RuleFor(x => x.種別コード区分, f => 3)
+            .RuleFor(x => x.コード区分, f => 0)
+            .RuleFor(x => x.作成日, f => f.Date.Past().ToDateOnly())
+            .RuleFor(x => x.勘定日開始, f => f.Date.Past().ToDateOnly())
+            .RuleFor(x => x.勘定日終了, f => f.Date.Past().ToDateOnly())
+            .RuleFor(x => x.銀行コード, f => f.Random.Int(0, 9999))
+            .RuleFor(x => x.銀行名, f => f.Random.String2(1, 15))
+            .RuleFor(x => x.支店コード, f => f.Random.Int(0, 999))
+            .RuleFor(x => x.支店名, f => f.Random.String2(1, 15))
+            .RuleFor(x => x.ダミー, f => "000")
+            .RuleFor(x => x.預金種目, f => f.Random.Int(0, 9))
+            .RuleFor(x => x.口座番号, f => f.Random.Long(0, 9999999999))
+            .RuleFor(x => x.口座名, f => f.Random.String2(1, 40))
+            .RuleFor(x => x.貸越区分, f => f.Random.Int(0, 9))
+            .RuleFor(x => x.通帳証書区分, f => f.Random.Int(0, 9))
+            .RuleFor(x => x.取引前残高, f => f.Random.Long(0, 99999999999999))
+            .RuleFor(x => x.ダミー2, f => new string(' ', 71));
+
+        var dataFaker = new Faker<入出金取引明細Data1>()
+            .RuleFor(x => x.データ区分, f => データ区分.Data)
+            .RuleFor(x => x.照会番号, f => f.Random.Int(0, 99999999))
+            .RuleFor(x => x.勘定日, f => f.Date.Past().ToDateOnly())
+            .RuleFor(x => x.預入払出日, f => f.Date.Past().ToDateOnly())
+            .RuleFor(x => x.入払区分, f => f.Random.Int(1, 2))
+            .RuleFor(x => x.取引区分, f => f.Random.Int(0, 99))
+            .RuleFor(x => x.取引金額, f => f.Random.Long(0, 999999999999))
+            .RuleFor(x => x.うち他店券金額, f => f.Random.Long(0, 999999999999))
+            .RuleFor(x => x.交換呈示日, f => f.Date.Past().ToDateOnly())
+            .RuleFor(x => x.不渡返還日, f => f.Date.Past().ToDateOnly())
+            .RuleFor(x => x.手形小切手区分, f => f.Random.Int(0, 9))
+            .RuleFor(x => x.手形小切手番号, f => f.Random.Int(0, 9999999))
+            .RuleFor(x => x.僚店番号, f => f.Random.Int(0, 999))
+            .RuleFor(x => x.振込依頼人コード, f => f.Random.Long(0, 9999999999))
+            .RuleFor(x => x.振込依頼人名または契約者番号, f => f.Random.String2(1, 48))
+            .RuleFor(x => x.仕向銀行名, f => f.Random.String2(1, 15))
+            .RuleFor(x => x.仕向店名, f => f.Random.String2(1, 15))
+            .RuleFor(x => x.摘要内容, f => f.Random.String2(1, 20))
+            .RuleFor(x => x.EDI情報, f => f.Random.String2(1, 20))
+            .RuleFor(x => x.ダミー, f => " ");
+
+        var trailerFaker = new Faker<入出金取引明細Trailer>()
+            .RuleFor(x => x.データ区分, f => データ区分.Trailer)
+            .RuleFor(x => x.入金件数, f => f.Random.Int(0, 999999))
+            .RuleFor(x => x.入金額合計, f => f.Random.Long(0, 9999999999999))
+            .RuleFor(x => x.出金件数, f => f.Random.Int(0, 999999))
+            .RuleFor(x => x.出金額合計, f => f.Random.Long(0, 9999999999999))
+            .RuleFor(x => x.貸越区分, f => f.Random.Int(0, 9))
+            .RuleFor(x => x.取引後残高, f => f.Random.Long(0, 99999999999999))
+            .RuleFor(x => x.データレコード件数, f => f.Random.Int(0, 9999999))
+            .RuleFor(x => x.ダミー, f => new string(' ', 139));
+
+        var endFaker = new Faker<入出金取引明細End>()
+            .RuleFor(x => x.データ区分, f => データ区分.End)
+            .RuleFor(x => x.レコード総件数, f => f.Random.Long(0, 9999999999))
+            .RuleFor(x => x.口座数, f => f.Random.Int(0, 99999))
+            .RuleFor(x => x.ダミー, f => new string(' ', 184));
+
+        var 入出金取引明細1 = new 入出金取引明細1
+        {
+            Header = headerFaker.Generate(),
+            DataList = dataFaker.Generate(10), // Generate multiple DataList items
+            Trailer = trailerFaker.Generate(),
+            End = endFaker.Generate()
+        };
+
+        return 入出金取引明細1;
+    }
+
+    public static 総合振込 GenerateRandom総合振込()
+    {
+        var headerFaker = new Faker<総合振込Header>()
+            .RuleFor(h => h.データ区分, f => データ区分.Header)
+            .RuleFor(h => h.種別コード, f => 21)
+            .RuleFor(h => h.コード区分, f => 0)
+            .RuleFor(h => h.振込依頼人コード, f => f.Random.Long(1000000000, 9999999999))
+            .RuleFor(h => h.振込依頼人名, f => f.Random.String2(1, 40))
+            .RuleFor(h => h.取組日, f => f.Date.Future().ToString("MMdd"))
+            .RuleFor(h => h.仕向銀行番号, f => f.Random.Int(1000, 9999))
+            .RuleFor(h => h.仕向銀行名, f => f.Random.String2(1, 15))
+            .RuleFor(h => h.仕向支店番号, f => f.Random.Int(100, 999))
+            .RuleFor(h => h.仕向支店名, f => f.Random.String2(1, 15))
+            .RuleFor(h => h.預金種目, f => f.Random.Int(1, 9))
+            .RuleFor(h => h.口座番号, f => f.Random.Int(1000000, 9999999))
+            .RuleFor(h => h.ダミー, f => new string(' ', 17));
+
+        var dataFaker = new Faker<総合振込Data>()
+            .RuleFor(d => d.データ区分, f => データ区分.Data)
+            .RuleFor(d => d.被仕向銀行番号, f => f.Random.Int(1000, 9999))
+            .RuleFor(d => d.被仕向銀行名, f => f.Random.String2(1, 15))
+            .RuleFor(d => d.被仕向支店番号, f => f.Random.Int(100, 999))
+            .RuleFor(d => d.被仕向支店名, f => f.Random.String2(1, 15))
+            .RuleFor(d => d.手形交換所番号, f => f.Random.Int(1000, 9999))
+            .RuleFor(d => d.預金種目, f => f.Random.Int(1, 9))
+            .RuleFor(d => d.口座番号, f => f.Random.Int(1000000, 9999999))
+            .RuleFor(d => d.受取人名, f => f.Random.String2(1, 30))
+            .RuleFor(d => d.振込金額, f => f.Random.Long(1000, 1000000))
+            .RuleFor(d => d.新規コード, f => f.Random.Int(0, 2))
+            .RuleFor(d => d.識別表示, f => f.Random.Bool())
+            .RuleFor(d => d.EDI情報, (f, d) => d.識別表示 ? f.Random.String2(1, 20) : null)
+            .RuleFor(d => d.顧客コード1, (f, d) => d.識別表示 ? null : f.Random.Long(1000000000, 9999999999))
+            .RuleFor(d => d.顧客コード2, (f, d) => d.識別表示 ? null : f.Random.Long(1000000000, 9999999999))
+            .RuleFor(d => d.振込指定区分, f => f.Random.Int(7, 8))
+            .RuleFor(d => d.ダミー, f => new string(' ', 7));
+
+        var trailerFaker = new Faker<総合振込Trailer>()
+            .RuleFor(t => t.データ区分, f => データ区分.Trailer)
+            .RuleFor(t => t.合計件数, f => f.Random.Int(1, 100))
+            .RuleFor(t => t.合計金額, f => f.Random.Long(1000, 1000000))
+            .RuleFor(t => t.ダミー, f => new string(' ', 101));
+
+        var endFaker = new Faker<総合振込End>()
+            .RuleFor(e => e.データ区分, f => データ区分.End)
+            .RuleFor(e => e.ダミー, f => new string(' ', 119));
+
+        var 総合振込 = new 総合振込
+        {
+            Header = headerFaker.Generate(),
+            DataList = dataFaker.Generate(10),
+            Trailer = trailerFaker.Generate(),
+            End = endFaker.Generate()
+        };
+
+        return 総合振込;
+    }
+}

--- a/Diva.Zengin.Tests/Reader/ZenginReaderTest.cs
+++ b/Diva.Zengin.Tests/Reader/ZenginReaderTest.cs
@@ -7,12 +7,14 @@ using Diva.Zengin.Formats;
 using JetBrains.Annotations;
 using Xunit;
 
-namespace Diva.Zengin.Tests.Readers;
+namespace Diva.Zengin.Tests.Reader;
 
 [TestSubject(typeof(ZenginReader<>))]
 public class ZenginReaderTest
 {
     [Theory]
+    [InlineData(typeof(List<振込入金通知A>))]
+    [InlineData(typeof(振込入金通知A[]))]
     [InlineData(typeof(List<入出金取引明細1>))]
     [InlineData(typeof(入出金取引明細1[]))]
     [InlineData(typeof(List<総合振込>))]
@@ -26,7 +28,7 @@ public class ZenginReaderTest
         var readAsyncMethod = readerType.GetMethod(nameof(ZenginReader<object>.ReadAsync));
         Assert.NotNull(readAsyncMethod);
         
-        var task = readAsyncMethod.Invoke(reader, null);
+        var task = readAsyncMethod.Invoke(reader, [FileFormat.Csv]);
         Assert.NotNull(task);
         
         // Get the awaiter via reflection
@@ -49,6 +51,7 @@ public class ZenginReaderTest
     }
 
     [Theory]
+    [InlineData(typeof(振込入金通知A))]
     [InlineData(typeof(入出金取引明細1))]
     [InlineData(typeof(総合振込))]
     public Task ReadAsync_SingleType_ReturnsNull(Type type)
@@ -60,7 +63,7 @@ public class ZenginReaderTest
         var readAsyncMethod = readerType.GetMethod(nameof(ZenginReader<object>.ReadAsync));
         Assert.NotNull(readAsyncMethod);
         
-        var task = readAsyncMethod.Invoke(reader, null);
+        var task = readAsyncMethod.Invoke(reader, [FileFormat.Csv]);
         Assert.NotNull(task);
         
         // Get the awaiter via reflection

--- a/Diva.Zengin.Tests/WriteReadTest.cs
+++ b/Diva.Zengin.Tests/WriteReadTest.cs
@@ -1,0 +1,218 @@
+using System.IO;
+using System.Threading.Tasks;
+using Diva.Zengin.Formats;
+using Xunit;
+
+namespace Diva.Zengin.Tests;
+
+/// <summary>
+/// レコードの各プロパティの値を乱数で生成し、ZenginWriterで書き込み、ZenginReaderで読み込み、元の値と一致することを確認する。
+/// </summary>
+public class WriteReadTest
+{
+    private static async Task WriteAsync<T>(T data, Stream stream, FileFormat format) where T : ISequence
+    {
+        var writer = new ZenginWriter<T>(stream);
+        await writer.WriteAsync(data, format);
+    }
+
+    private static async Task<T?> ReadAsync<T>(Stream stream, FileFormat format) where T : ISequence
+    {
+        var reader = new ZenginReader<T>(stream);
+        return await reader.ReadAsync(format);
+    }
+
+    [Theory]
+    [InlineData(FileFormat.Zengin)]
+    [InlineData(FileFormat.Csv)]
+    public async Task 振込入金通知A_WriteReadTest(FileFormat format)
+    {
+        var originalData = Generator.GenerateRandom振込入金通知A();
+        using var memoryStream = new MemoryStream();
+        await WriteAsync(originalData, memoryStream, format);
+
+        memoryStream.Seek(0, SeekOrigin.Begin); // Reset stream position for reading
+        var readData = await ReadAsync<振込入金通知A>(memoryStream, format);
+
+        Assert.NotNull(readData);
+
+        // Compare Header properties
+        Assert.Equal(originalData.Header.種別コード, readData.Header.種別コード);
+        Assert.Equal(originalData.Header.コード区分, readData.Header.コード区分);
+        Assert.Equal(originalData.Header.作成日, readData.Header.作成日);
+        Assert.Equal(originalData.Header.勘定日開始, readData.Header.勘定日開始);
+        Assert.Equal(originalData.Header.勘定日終了, readData.Header.勘定日終了);
+        Assert.Equal(originalData.Header.銀行コード, readData.Header.銀行コード);
+        Assert.Equal(originalData.Header.銀行名, readData.Header.銀行名);
+        Assert.Equal(originalData.Header.支店コード, readData.Header.支店コード);
+        Assert.Equal(originalData.Header.支店名, readData.Header.支店名);
+        Assert.Equal(originalData.Header.預金種目, readData.Header.預金種目);
+        Assert.Equal(originalData.Header.口座番号, readData.Header.口座番号);
+        Assert.Equal(originalData.Header.口座名, readData.Header.口座名);
+        Assert.Equal(originalData.Header.ダミー.Trim(), readData.Header.ダミー);
+
+        // Compare DataList properties
+        for (var i = 0; i < originalData.DataList.Count; i++)
+        {
+            Assert.Equal(originalData.DataList[i].データ区分, readData.DataList[i].データ区分);
+            Assert.Equal(originalData.DataList[i].照会番号, readData.DataList[i].照会番号);
+            Assert.Equal(originalData.DataList[i].勘定日, readData.DataList[i].勘定日);
+            Assert.Equal(originalData.DataList[i].起算日, readData.DataList[i].起算日);
+            Assert.Equal(originalData.DataList[i].金額, readData.DataList[i].金額);
+            Assert.Equal(originalData.DataList[i].うち他店券金額, readData.DataList[i].うち他店券金額);
+            Assert.Equal(originalData.DataList[i].振込依頼人コード, readData.DataList[i].振込依頼人コード);
+            Assert.Equal(originalData.DataList[i].振込依頼人名, readData.DataList[i].振込依頼人名);
+            Assert.Equal(originalData.DataList[i].仕向銀行名, readData.DataList[i].仕向銀行名);
+            Assert.Equal(originalData.DataList[i].仕向店名, readData.DataList[i].仕向店名);
+            Assert.Equal(originalData.DataList[i].取消区分, readData.DataList[i].取消区分);
+            Assert.Equal(originalData.DataList[i].EDI情報, readData.DataList[i].EDI情報);
+            Assert.Equal(originalData.DataList[i].ダミー.Trim(), readData.DataList[i].ダミー);
+        }
+
+        // Compare Trailer properties
+        Assert.Equal(originalData.Trailer.データ区分, readData.Trailer.データ区分);
+        Assert.Equal(originalData.Trailer.振込合計件数, readData.Trailer.振込合計件数);
+        Assert.Equal(originalData.Trailer.振込合計金額, readData.Trailer.振込合計金額);
+        Assert.Equal(originalData.Trailer.取消合計件数, readData.Trailer.取消合計件数);
+        Assert.Equal(originalData.Trailer.取消合計金額, readData.Trailer.取消合計金額);
+        Assert.Equal(originalData.Trailer.ダミー.Trim(), readData.Trailer.ダミー);
+
+        // Compare End properties
+        Assert.Equal(originalData.End.データ区分, readData.End.データ区分);
+        Assert.Equal(originalData.End.ダミー.Trim(), readData.End.ダミー);
+    }
+
+
+    [Theory]
+    [InlineData(FileFormat.Zengin)]
+    [InlineData(FileFormat.Csv)]
+    public async Task 入出金取引明細1_WriteReadTest(FileFormat format)
+    {
+        var originalData = Generator.GenerateRandom入出金取引明細1();
+        using var memoryStream = new MemoryStream();
+        await WriteAsync(originalData, memoryStream, format);
+
+        memoryStream.Seek(0, SeekOrigin.Begin); // Reset stream position for reading
+        var readData = await ReadAsync<入出金取引明細1>(memoryStream, format);
+
+        Assert.NotNull(readData);
+
+        // Compare Header properties
+        Assert.Equal(originalData.Header.種別コード区分, readData.Header.種別コード区分);
+        Assert.Equal(originalData.Header.コード区分, readData.Header.コード区分);
+        Assert.Equal(originalData.Header.作成日, readData.Header.作成日);
+        Assert.Equal(originalData.Header.勘定日開始, readData.Header.勘定日開始);
+        Assert.Equal(originalData.Header.勘定日終了, readData.Header.勘定日終了);
+        Assert.Equal(originalData.Header.銀行コード, readData.Header.銀行コード);
+        Assert.Equal(originalData.Header.銀行名, readData.Header.銀行名);
+        Assert.Equal(originalData.Header.支店コード, readData.Header.支店コード);
+        Assert.Equal(originalData.Header.支店名, readData.Header.支店名);
+        Assert.Equal(originalData.Header.預金種目, readData.Header.預金種目);
+        Assert.Equal(originalData.Header.口座番号, readData.Header.口座番号);
+        Assert.Equal(originalData.Header.口座名, readData.Header.口座名);
+        Assert.Equal(originalData.Header.ダミー.Trim(), readData.Header.ダミー.Trim());
+
+        // Compare DataList properties
+        for (var i = 0; i < originalData.DataList.Count; i++)
+        {
+            Assert.Equal(originalData.DataList[i].データ区分, readData.DataList[i].データ区分);
+            Assert.Equal(originalData.DataList[i].照会番号, readData.DataList[i].照会番号);
+            Assert.Equal(originalData.DataList[i].勘定日, readData.DataList[i].勘定日);
+            Assert.Equal(originalData.DataList[i].預入払出日, readData.DataList[i].預入払出日);
+            Assert.Equal(originalData.DataList[i].入払区分, readData.DataList[i].入払区分);
+            Assert.Equal(originalData.DataList[i].取引区分, readData.DataList[i].取引区分);
+            Assert.Equal(originalData.DataList[i].取引金額, readData.DataList[i].取引金額);
+            Assert.Equal(originalData.DataList[i].うち他店券金額, readData.DataList[i].うち他店券金額);
+            Assert.Equal(originalData.DataList[i].交換呈示日, readData.DataList[i].交換呈示日);
+            Assert.Equal(originalData.DataList[i].不渡返還日, readData.DataList[i].不渡返還日);
+            Assert.Equal(originalData.DataList[i].手形小切手区分, readData.DataList[i].手形小切手区分);
+            Assert.Equal(originalData.DataList[i].手形小切手番号, readData.DataList[i].手形小切手番号);
+            Assert.Equal(originalData.DataList[i].僚店番号, readData.DataList[i].僚店番号);
+            Assert.Equal(originalData.DataList[i].振込依頼人コード, readData.DataList[i].振込依頼人コード);
+            Assert.Equal(originalData.DataList[i].振込依頼人名または契約者番号, readData.DataList[i].振込依頼人名または契約者番号);
+            Assert.Equal(originalData.DataList[i].仕向銀行名, readData.DataList[i].仕向銀行名);
+            Assert.Equal(originalData.DataList[i].仕向店名, readData.DataList[i].仕向店名);
+            Assert.Equal(originalData.DataList[i].摘要内容, readData.DataList[i].摘要内容);
+            Assert.Equal(originalData.DataList[i].EDI情報, readData.DataList[i].EDI情報);
+            Assert.Equal(originalData.DataList[i].ダミー.Trim(), readData.DataList[i].ダミー.Trim());
+        }
+
+        // Compare Trailer properties
+        Assert.Equal(originalData.Trailer.データ区分, readData.Trailer.データ区分);
+        Assert.Equal(originalData.Trailer.入金件数, readData.Trailer.入金件数);
+        Assert.Equal(originalData.Trailer.入金額合計, readData.Trailer.入金額合計);
+        Assert.Equal(originalData.Trailer.出金件数, readData.Trailer.出金件数);
+        Assert.Equal(originalData.Trailer.出金額合計, readData.Trailer.出金額合計);
+        Assert.Equal(originalData.Trailer.貸越区分, readData.Trailer.貸越区分);
+        Assert.Equal(originalData.Trailer.取引後残高, readData.Trailer.取引後残高);
+        Assert.Equal(originalData.Trailer.データレコード件数, readData.Trailer.データレコード件数);
+        Assert.Equal(originalData.Trailer.ダミー.Trim(), readData.Trailer.ダミー.Trim());
+
+        // Compare End properties
+        Assert.Equal(originalData.End.データ区分, readData.End.データ区分);
+        Assert.Equal(originalData.End.レコード総件数, readData.End.レコード総件数);
+        Assert.Equal(originalData.End.口座数, readData.End.口座数);
+        Assert.Equal(originalData.End.ダミー.Trim(), readData.End.ダミー.Trim());
+    }
+
+    [Theory]
+    [InlineData(FileFormat.Zengin)]
+    [InlineData(FileFormat.Csv)]
+    public async Task 総合振込_WriteReadTest(FileFormat format)
+    {
+        var originalData = Generator.GenerateRandom総合振込();
+        using var memoryStream = new MemoryStream();
+        await WriteAsync(originalData, memoryStream, format);
+
+        memoryStream.Seek(0, SeekOrigin.Begin); // Reset stream position for reading
+        var readData = await ReadAsync<総合振込>(memoryStream, format);
+
+        Assert.NotNull(readData);
+
+        // Compare Header properties
+        Assert.Equal(originalData.Header.種別コード, readData.Header.種別コード);
+        Assert.Equal(originalData.Header.コード区分, readData.Header.コード区分);
+        Assert.Equal(originalData.Header.振込依頼人コード, readData.Header.振込依頼人コード);
+        Assert.Equal(originalData.Header.振込依頼人名, readData.Header.振込依頼人名);
+        Assert.Equal(originalData.Header.取組日, readData.Header.取組日);
+        Assert.Equal(originalData.Header.仕向銀行番号, readData.Header.仕向銀行番号);
+        Assert.Equal(originalData.Header.仕向銀行名, readData.Header.仕向銀行名);
+        Assert.Equal(originalData.Header.仕向支店番号, readData.Header.仕向支店番号);
+        Assert.Equal(originalData.Header.仕向支店名, readData.Header.仕向支店名);
+        Assert.Equal(originalData.Header.預金種目, readData.Header.預金種目);
+        Assert.Equal(originalData.Header.口座番号, readData.Header.口座番号);
+        Assert.Equal(originalData.Header.ダミー.Trim(), readData.Header.ダミー.Trim());
+
+        // Compare DataList properties
+        for (var i = 0; i < originalData.DataList.Count; i++)
+        {
+            Assert.Equal(originalData.DataList[i].データ区分, readData.DataList[i].データ区分);
+            Assert.Equal(originalData.DataList[i].被仕向銀行番号, readData.DataList[i].被仕向銀行番号);
+            Assert.Equal(originalData.DataList[i].被仕向銀行名, readData.DataList[i].被仕向銀行名);
+            Assert.Equal(originalData.DataList[i].被仕向支店番号, readData.DataList[i].被仕向支店番号);
+            Assert.Equal(originalData.DataList[i].被仕向支店名, readData.DataList[i].被仕向支店名);
+            Assert.Equal(originalData.DataList[i].手形交換所番号, readData.DataList[i].手形交換所番号);
+            Assert.Equal(originalData.DataList[i].預金種目, readData.DataList[i].預金種目);
+            Assert.Equal(originalData.DataList[i].口座番号, readData.DataList[i].口座番号);
+            Assert.Equal(originalData.DataList[i].受取人名, readData.DataList[i].受取人名);
+            Assert.Equal(originalData.DataList[i].振込金額, readData.DataList[i].振込金額);
+            Assert.Equal(originalData.DataList[i].新規コード, readData.DataList[i].新規コード);
+            Assert.Equal(originalData.DataList[i].識別表示, readData.DataList[i].識別表示);
+            Assert.Equal(originalData.DataList[i].EDI情報, readData.DataList[i].EDI情報);
+            Assert.Equal(originalData.DataList[i].顧客コード1, readData.DataList[i].顧客コード1);
+            Assert.Equal(originalData.DataList[i].顧客コード2, readData.DataList[i].顧客コード2);
+            Assert.Equal(originalData.DataList[i].振込指定区分, readData.DataList[i].振込指定区分);
+            Assert.Equal(originalData.DataList[i].ダミー.Trim(), readData.DataList[i].ダミー.Trim());
+        }
+
+        // Compare Trailer properties
+        Assert.Equal(originalData.Trailer.データ区分, readData.Trailer.データ区分);
+        Assert.Equal(originalData.Trailer.合計件数, readData.Trailer.合計件数);
+        Assert.Equal(originalData.Trailer.合計金額, readData.Trailer.合計金額);
+        Assert.Equal(originalData.Trailer.ダミー.Trim(), readData.Trailer.ダミー.Trim());
+
+        // Compare End properties
+        Assert.Equal(originalData.End.データ区分, readData.End.データ区分);
+        Assert.Equal(originalData.End.ダミー.Trim(), readData.End.ダミー.Trim());
+    }
+}

--- a/Diva.Zengin.Tests/ZenginReaderTest.cs
+++ b/Diva.Zengin.Tests/ZenginReaderTest.cs
@@ -7,11 +7,19 @@ using Diva.Zengin.Formats;
 using JetBrains.Annotations;
 using Xunit;
 
-namespace Diva.Zengin.Tests.Reader;
+namespace Diva.Zengin.Tests;
 
+/// <summary>
+/// ZenginReader のテストクラス。
+/// </summary>
 [TestSubject(typeof(ZenginReader<>))]
 public class ZenginReaderTest
 {
+    /// <summary>
+    /// 結果がない場合、TにレコードclassのList, Arrayを指定していた場合は空のコレクションを返す。
+    /// </summary>
+    /// <param name="type"></param>
+    /// <returns></returns>
     [Theory]
     [InlineData(typeof(List<振込入金通知A>))]
     [InlineData(typeof(振込入金通知A[]))]
@@ -50,6 +58,11 @@ public class ZenginReaderTest
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// 結果がない場合、Tにレコードclassを指定していた場合はnullを返す。
+    /// </summary>
+    /// <param name="type"></param>
+    /// <returns></returns>
     [Theory]
     [InlineData(typeof(振込入金通知A))]
     [InlineData(typeof(入出金取引明細1))]

--- a/Diva.Zengin/Formats/入出金取引明細Data1.cs
+++ b/Diva.Zengin/Formats/入出金取引明細Data1.cs
@@ -127,8 +127,8 @@ public class 入出金取引明細Data1 : IRecord
     /// </summary>
     /// <remarks>任意項目</remarks>
     [Index(13)]
-    [TypeConverter(typeof(NumberTypeConverter<int?>), 10)]
-    public int? 振込依頼人コード { get; set; }
+    [TypeConverter(typeof(NumberTypeConverter<decimal?>), 10)]
+    public decimal? 振込依頼人コード { get; set; }
 
     /// <summary>
     /// 振込依頼人名または契約者番号 (C(48))

--- a/Diva.Zengin/Formats/入出金取引明細Header.cs
+++ b/Diva.Zengin/Formats/入出金取引明細Header.cs
@@ -109,8 +109,8 @@ public class 入出金取引明細Header : IRecord
     /// 右詰め・前0埋め
     /// </summary>
     [Index(12)]
-    [TypeConverter(typeof(NumberTypeConverter<int>), 10)]
-    public int 口座番号 { get; set; }
+    [TypeConverter(typeof(NumberTypeConverter<decimal>), 10)]
+    public decimal 口座番号 { get; set; }
 
     /// <summary>
     /// 口座名 (C(40))  

--- a/Diva.Zengin/Formats/総合振込Header.cs
+++ b/Diva.Zengin/Formats/総合振込Header.cs
@@ -54,6 +54,7 @@ public class 総合振込Header : IRecord
     /// 振込日を表わす。 MMDD (月-日)
     /// </summary>
     [Index(5)]
+    [TypeConverter(typeof(CharacterTypeConverter), 4)]
     public string 取組日 { get; set; }
 
     /// <summary>

--- a/Diva.Zengin/ZenginReaderCore.cs
+++ b/Diva.Zengin/ZenginReaderCore.cs
@@ -190,7 +190,7 @@ internal class ZenginReaderCore<TSequence, THeader, TData, TTrailer, TEnd>
             case データ区分.Data:
                 if (typeof(TData) == typeof(総合振込Data))
                 {
-                    indexToLengthMap = zenginLine[111] == 'Y'
+                    indexToLengthMap = zenginLine[112] == 'Y'
                         ? PropertyAnalyzer.GetIndexToLengthMap<総合振込WriteData1>()
                         : PropertyAnalyzer.GetIndexToLengthMap<総合振込WriteData2>();
                 }


### PR DESCRIPTION

This pull request includes several changes to the test files in the `Diva.Zengin.Tests` project. The most important changes involve adding new unit tests for `CharacterConverter` and `NumberConverter`, enabling nullable reference types, and renaming a test file.

### New Unit Tests:
* [`Diva.Zengin.Tests/Converters/CharacterConverterTest.cs`](diffhunk://#diff-f79cf21f782dceb169f22e276a323449d6382195e984fe3fbac106175a9998b5R1-R37): Added tests for `CharacterConverter` to handle various input scenarios for `ConvertFromString` and `ConvertToString` methods.
* [`Diva.Zengin.Tests/Converters/NumberConverterTest.cs`](diffhunk://#diff-dd8d6f5163dec8bd85c25af16cae0390cb590774439144cecf115df070cd144bR1-R73): Added tests for `NumberConverter` to handle null or empty strings, valid integers, valid decimals, enums, and formatted string outputs.

### Project Configuration:
* [`Diva.Zengin.Tests/Diva.Zengin.Tests.csproj`](diffhunk://#diff-a9536ab2edce6f4edfe3f4664c5b81f9753ed2d6a13055ad4ae75da393336614R7-R8): Enabled nullable reference types by adding `<Nullable>enable</Nullable>` to the project file.

### File Renaming:
* [`Diva.Zengin.Tests/Reader/ZenginReaderTest.cs`](diffhunk://#diff-78581edb2862504c68b3f8f8176adfceb85b010a41bd89e61929da184608656dL10-R17): Renamed from `Diva.Zengin.Tests/Readers/ZenginReaderTest.cs` to correct the namespace and file structure.

### Test Method Updates:
* [`Diva.Zengin.Tests/Reader/ZenginReaderTest.cs`](diffhunk://#diff-78581edb2862504c68b3f8f8176adfceb85b010a41bd89e61929da184608656dL29-R31): Updated `ReadAsync_CollectionType_ReturnsEmpty` and `ReadAsync_SingleType_ReturnsNull` methods to include `FileFormat.Csv` as a parameter when invoking `ReadAsync` method. [[1]](diffhunk://#diff-78581edb2862504c68b3f8f8176adfceb85b010a41bd89e61929da184608656dL29-R31) [[2]](diffhunk://#diff-78581edb2862504c68b3f8f8176adfceb85b010a41bd89e61929da184608656dL63-R66)