### PR TITLE
Refactor namespaces and introduce ZenginConfiguration for improved st…

### DIFF
--- a/Diva.Zengin.SourceGenerator/IndexToLengthMapGenerator.cs
+++ b/Diva.Zengin.SourceGenerator/IndexToLengthMapGenerator.cs
@@ -27,7 +27,7 @@ public class IndexToLengthMapGenerator : IIncrementalGenerator
                 """);
             context.AddSource("IIndexToLengthMap.cs",
                 """
-                namespace Diva.Zengin.Formats;
+                namespace Diva.Zengin;
                 
                 public interface IIndexToLengthMap
                 {

--- a/Diva.Zengin.Tests/Generator.cs
+++ b/Diva.Zengin.Tests/Generator.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Bogus;
-using Diva.Zengin.Formats;
+using Diva.Zengin.Records;
 
 namespace Diva.Zengin.Tests;
 

--- a/Diva.Zengin.Tests/WriteReadTest.cs
+++ b/Diva.Zengin.Tests/WriteReadTest.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Threading.Tasks;
-using Diva.Zengin.Formats;
+using Diva.Zengin.Configuration;
+using Diva.Zengin.Records;
 using Xunit;
 
 namespace Diva.Zengin.Tests;
@@ -12,14 +13,22 @@ public class WriteReadTest
 {
     private static async Task WriteAsync<T>(T data, Stream stream, FileFormat format) where T : ISequence
     {
-        var writer = new ZenginWriter<T>(stream);
-        await writer.WriteAsync(data, format);
+        var config = new ZenginConfiguration
+        {
+            FileFormat = format,
+        };
+        var writer = new ZenginWriter<T>(stream, config);
+        await writer.WriteAsync(data);
     }
 
     private static async Task<T?> ReadAsync<T>(Stream stream, FileFormat format) where T : ISequence
     {
-        var reader = new ZenginReader<T>(stream);
-        return await reader.ReadAsync(format);
+        var config = new ZenginConfiguration
+        {
+            FileFormat = format,
+        };
+        var reader = new ZenginReader<T>(stream, config);
+        return await reader.ReadAsync();
     }
 
     [Theory]

--- a/Diva.Zengin.Tests/ZenginReaderTest.cs
+++ b/Diva.Zengin.Tests/ZenginReaderTest.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using Diva.Zengin.Formats;
+using Diva.Zengin.Records;
 using JetBrains.Annotations;
 using Xunit;
 
@@ -36,7 +36,7 @@ public class ZenginReaderTest
         var readAsyncMethod = readerType.GetMethod(nameof(ZenginReader<object>.ReadAsync));
         Assert.NotNull(readAsyncMethod);
         
-        var task = readAsyncMethod.Invoke(reader, [FileFormat.Csv]);
+        var task = readAsyncMethod.Invoke(reader, null);
         Assert.NotNull(task);
         
         // Get the awaiter via reflection
@@ -76,7 +76,7 @@ public class ZenginReaderTest
         var readAsyncMethod = readerType.GetMethod(nameof(ZenginReader<object>.ReadAsync));
         Assert.NotNull(readAsyncMethod);
         
-        var task = readAsyncMethod.Invoke(reader, [FileFormat.Csv]);
+        var task = readAsyncMethod.Invoke(reader, null);
         Assert.NotNull(task);
         
         // Get the awaiter via reflection

--- a/Diva.Zengin/Configuration/FileFormat.cs
+++ b/Diva.Zengin/Configuration/FileFormat.cs
@@ -1,4 +1,4 @@
-namespace Diva.Zengin.Formats;
+namespace Diva.Zengin.Configuration;
 
 public enum FileFormat
 {

--- a/Diva.Zengin/Configuration/ZenginConfiguration.cs
+++ b/Diva.Zengin/Configuration/ZenginConfiguration.cs
@@ -1,0 +1,6 @@
+namespace Diva.Zengin.Configuration;
+
+public record ZenginConfiguration
+{
+    public FileFormat FileFormat { get; set; } = FileFormat.Zengin;
+}

--- a/Diva.Zengin/Mappers/総合振込DataMapper.cs
+++ b/Diva.Zengin/Mappers/総合振込DataMapper.cs
@@ -1,4 +1,4 @@
-using Diva.Zengin.Formats;
+using Diva.Zengin.Records;
 using Riok.Mapperly.Abstractions;
 
 namespace Diva.Zengin.Mappers;

--- a/Diva.Zengin/PropertyAnalyzer.cs
+++ b/Diva.Zengin/PropertyAnalyzer.cs
@@ -2,7 +2,7 @@ using System.Collections.ObjectModel;
 using System.Reflection;
 using CsvHelper.Configuration.Attributes;
 using Diva.Zengin.Converters;
-using Diva.Zengin.Formats;
+using Diva.Zengin.Records;
 using TypeConverterAttribute = CsvHelper.Configuration.Attributes.TypeConverterAttribute;
 
 namespace Diva.Zengin;

--- a/Diva.Zengin/Records/IRecord.cs
+++ b/Diva.Zengin/Records/IRecord.cs
@@ -1,4 +1,4 @@
-namespace Diva.Zengin.Formats;
+namespace Diva.Zengin.Records;
 
 public interface IRecord
 {

--- a/Diva.Zengin/Records/ISequence.cs
+++ b/Diva.Zengin/Records/ISequence.cs
@@ -1,4 +1,4 @@
-namespace Diva.Zengin.Formats;
+namespace Diva.Zengin.Records;
 
 public interface ISequence;
 

--- a/Diva.Zengin/Records/データ区分.cs
+++ b/Diva.Zengin/Records/データ区分.cs
@@ -1,4 +1,4 @@
-namespace Diva.Zengin.Formats;
+namespace Diva.Zengin.Records;
 
 public enum データ区分
 {

--- a/Diva.Zengin/Records/入出金取引明細1.cs
+++ b/Diva.Zengin/Records/入出金取引明細1.cs
@@ -1,4 +1,4 @@
-namespace Diva.Zengin.Formats;
+namespace Diva.Zengin.Records;
 
 /// <summary>
 /// 入出金明細（普通預金・当座預金・貯蓄預金の場合）

--- a/Diva.Zengin/Records/入出金取引明細Data1.cs
+++ b/Diva.Zengin/Records/入出金取引明細Data1.cs
@@ -1,7 +1,7 @@
 using CsvHelper.Configuration.Attributes;
 using Diva.Zengin.Converters;
 
-namespace Diva.Zengin.Formats;
+namespace Diva.Zengin.Records;
 
 /// <summary>
 /// 入出金取引明細のデータ・レコードを表すクラス。

--- a/Diva.Zengin/Records/入出金取引明細End.cs
+++ b/Diva.Zengin/Records/入出金取引明細End.cs
@@ -1,7 +1,7 @@
 using CsvHelper.Configuration.Attributes;
 using Diva.Zengin.Converters;
 
-namespace Diva.Zengin.Formats;
+namespace Diva.Zengin.Records;
 
 /// <summary>
 /// 入出金取引明細のエンド・レコードを表すクラス。

--- a/Diva.Zengin/Records/入出金取引明細Header.cs
+++ b/Diva.Zengin/Records/入出金取引明細Header.cs
@@ -1,7 +1,7 @@
 using CsvHelper.Configuration.Attributes;
 using Diva.Zengin.Converters;
 
-namespace Diva.Zengin.Formats;
+namespace Diva.Zengin.Records;
 
 /// <summary>
 /// 入出金取引明細のヘッダー・レコードを表すクラス。

--- a/Diva.Zengin/Records/入出金取引明細Trailer.cs
+++ b/Diva.Zengin/Records/入出金取引明細Trailer.cs
@@ -1,7 +1,7 @@
 using CsvHelper.Configuration.Attributes;
 using Diva.Zengin.Converters;
 
-namespace Diva.Zengin.Formats;
+namespace Diva.Zengin.Records;
 
 /// <summary>
 /// 入出金取引明細のトレーラ・レコードを表すクラス。

--- a/Diva.Zengin/Records/振込入金通知A.cs
+++ b/Diva.Zengin/Records/振込入金通知A.cs
@@ -1,4 +1,4 @@
-namespace Diva.Zengin.Formats;
+namespace Diva.Zengin.Records;
 
 /// <summary>
 /// 振込入金通知の全体を表すクラス。

--- a/Diva.Zengin/Records/振込入金通知DataA.cs
+++ b/Diva.Zengin/Records/振込入金通知DataA.cs
@@ -1,7 +1,7 @@
 using CsvHelper.Configuration.Attributes;
 using Diva.Zengin.Converters;
 
-namespace Diva.Zengin.Formats;
+namespace Diva.Zengin.Records;
 
 /// <summary>
 /// 振込入金通知のデータ・レコードを表すクラス。

--- a/Diva.Zengin/Records/振込入金通知End.cs
+++ b/Diva.Zengin/Records/振込入金通知End.cs
@@ -1,7 +1,7 @@
 using CsvHelper.Configuration.Attributes;
 using Diva.Zengin.Converters;
 
-namespace Diva.Zengin.Formats;
+namespace Diva.Zengin.Records;
 
 /// <summary>
 /// 振込入金通知のエンド・レコードを表すクラス。

--- a/Diva.Zengin/Records/振込入金通知Header.cs
+++ b/Diva.Zengin/Records/振込入金通知Header.cs
@@ -1,7 +1,7 @@
 using CsvHelper.Configuration.Attributes;
 using Diva.Zengin.Converters;
 
-namespace Diva.Zengin.Formats;
+namespace Diva.Zengin.Records;
 
 /// <summary>
 /// 振込入金通知のヘッダー・レコードを表すクラス。

--- a/Diva.Zengin/Records/振込入金通知Trailer.cs
+++ b/Diva.Zengin/Records/振込入金通知Trailer.cs
@@ -1,7 +1,7 @@
 using CsvHelper.Configuration.Attributes;
 using Diva.Zengin.Converters;
 
-namespace Diva.Zengin.Formats;
+namespace Diva.Zengin.Records;
 
 /// <summary>
 /// 振込入金通知のトレーラ・レコードを表すクラス。

--- a/Diva.Zengin/Records/総合振込.cs
+++ b/Diva.Zengin/Records/総合振込.cs
@@ -1,4 +1,4 @@
-namespace Diva.Zengin.Formats;
+namespace Diva.Zengin.Records;
 
 public class 総合振込 : ISequence<総合振込Header, 総合振込Data, 総合振込Trailer, 総合振込End>
 {

--- a/Diva.Zengin/Records/総合振込Data.cs
+++ b/Diva.Zengin/Records/総合振込Data.cs
@@ -1,4 +1,4 @@
-namespace Diva.Zengin.Formats;
+namespace Diva.Zengin.Records;
 
 /// <summary>
 /// 総合振込のデータ・レコードを表すクラス。

--- a/Diva.Zengin/Records/総合振込DataReadMap.cs
+++ b/Diva.Zengin/Records/総合振込DataReadMap.cs
@@ -2,7 +2,7 @@ using CsvHelper;
 using CsvHelper.Configuration;
 using Diva.Zengin.Converters;
 
-namespace Diva.Zengin.Formats;
+namespace Diva.Zengin.Records;
 
 /// <summary>
 /// 総合振込データの列マッピング定義（読み込み時）

--- a/Diva.Zengin/Records/総合振込End.cs
+++ b/Diva.Zengin/Records/総合振込End.cs
@@ -1,7 +1,7 @@
 using CsvHelper.Configuration.Attributes;
 using Diva.Zengin.Converters;
 
-namespace Diva.Zengin.Formats;
+namespace Diva.Zengin.Records;
 
 /// <summary>
 /// 総合振込のエンド・レコードを表すクラス。

--- a/Diva.Zengin/Records/総合振込Header.cs
+++ b/Diva.Zengin/Records/総合振込Header.cs
@@ -1,7 +1,7 @@
 using CsvHelper.Configuration.Attributes;
 using Diva.Zengin.Converters;
 
-namespace Diva.Zengin.Formats;
+namespace Diva.Zengin.Records;
 
 /// <summary>
 /// 総合振込のヘッダー・レコードを表すクラス。

--- a/Diva.Zengin/Records/総合振込Trailer.cs
+++ b/Diva.Zengin/Records/総合振込Trailer.cs
@@ -1,7 +1,7 @@
 using CsvHelper.Configuration.Attributes;
 using Diva.Zengin.Converters;
 
-namespace Diva.Zengin.Formats;
+namespace Diva.Zengin.Records;
 
 /// <summary>
 /// 総合振込のトレーラ・レコードを表すクラス。

--- a/Diva.Zengin/Records/総合振込WriteData1.cs
+++ b/Diva.Zengin/Records/総合振込WriteData1.cs
@@ -1,14 +1,14 @@
 using CsvHelper.Configuration.Attributes;
 using Diva.Zengin.Converters;
 
-namespace Diva.Zengin.Formats;
+namespace Diva.Zengin.Records;
 
 /// <summary>
 /// 総合振込のデータ・レコードを表すクラス。
-/// 顧客コードを持つ。
+/// EDI情報を持つ。
 /// </summary>
 [IndexToLengthMap]
-public partial class 総合振込WriteData2 : IRecord
+public partial class 総合振込WriteData1 : IRecord
 {
     /// <summary>
     /// データ区分 (N(1))  
@@ -102,29 +102,21 @@ public partial class 総合振込WriteData2 : IRecord
     public int 新規コード { get; set; }
 
     /// <summary>
-    /// 顧客コード1 (N(10))  
-    /// 依頼人が定めた受取人識別のための顧客コードを表わす。識別表示が空白の場合のみ。
+    /// EDI情報 (C(20))
+    /// 依頼人から受取人に対して通知するEDI情報を表わす。識別表示が「Y」の場合のみ。
+    /// 左詰め残りスペース
     /// </summary>
     /// <remarks>任意項目</remarks>
     [Index(11)]
-    [TypeConverter(typeof(NumberTypeConverter<decimal?>), 10)]
-    public decimal? 顧客コード1 { get; set; }
-
-    /// <summary>
-    /// 顧客コード2 (N(10))  
-    /// 依頼人が定めた受取人識別のための顧客コードを表わす。識別表示が空白の場合のみ。
-    /// </summary>
-    /// <remarks>任意項目</remarks>
-    [Index(12)]
-    [TypeConverter(typeof(NumberTypeConverter<decimal?>), 10)]
-    public decimal? 顧客コード2 { get; set; }
+    [TypeConverter(typeof(CharacterTypeConverter), 20)]
+    public string? EDI情報 { get; set; }
 
     /// <summary>
     /// 振込指定区分 (N(1))  
     /// 7: テレ振込, 8: 文書振込
     /// </summary>
     /// <remarks>任意項目</remarks>
-    [Index(13)]
+    [Index(12)]
     [TypeConverter(typeof(NumberTypeConverter<int?>), 1)]
     public int? 振込指定区分 { get; set; }
 
@@ -134,7 +126,7 @@ public partial class 総合振込WriteData2 : IRecord
     /// 本欄に「Y」表示を付した場合は、「EDI情報」を含む。 
     /// </summary>
     /// <remarks>任意項目</remarks>
-    [Index(14)]
+    [Index(13)]
     [BooleanTrueValues("Y")]
     [BooleanFalseValues(" ")]
     public bool 識別表示 { get; set; }
@@ -143,7 +135,7 @@ public partial class 総合振込WriteData2 : IRecord
     /// ダミー (C(7))  
     /// スペース
     /// </summary>
-    [Index(15)]
+    [Index(14)]
     [TypeConverter(typeof(CharacterTypeConverter), 7)]
     public string ダミー { get; set; } = "";
 }

--- a/Diva.Zengin/Records/総合振込WriteData2.cs
+++ b/Diva.Zengin/Records/総合振込WriteData2.cs
@@ -1,14 +1,14 @@
 using CsvHelper.Configuration.Attributes;
 using Diva.Zengin.Converters;
 
-namespace Diva.Zengin.Formats;
+namespace Diva.Zengin.Records;
 
 /// <summary>
 /// 総合振込のデータ・レコードを表すクラス。
-/// EDI情報を持つ。
+/// 顧客コードを持つ。
 /// </summary>
 [IndexToLengthMap]
-public partial class 総合振込WriteData1 : IRecord
+public partial class 総合振込WriteData2 : IRecord
 {
     /// <summary>
     /// データ区分 (N(1))  
@@ -102,21 +102,29 @@ public partial class 総合振込WriteData1 : IRecord
     public int 新規コード { get; set; }
 
     /// <summary>
-    /// EDI情報 (C(20))
-    /// 依頼人から受取人に対して通知するEDI情報を表わす。識別表示が「Y」の場合のみ。
-    /// 左詰め残りスペース
+    /// 顧客コード1 (N(10))  
+    /// 依頼人が定めた受取人識別のための顧客コードを表わす。識別表示が空白の場合のみ。
     /// </summary>
     /// <remarks>任意項目</remarks>
     [Index(11)]
-    [TypeConverter(typeof(CharacterTypeConverter), 20)]
-    public string? EDI情報 { get; set; }
+    [TypeConverter(typeof(NumberTypeConverter<decimal?>), 10)]
+    public decimal? 顧客コード1 { get; set; }
+
+    /// <summary>
+    /// 顧客コード2 (N(10))  
+    /// 依頼人が定めた受取人識別のための顧客コードを表わす。識別表示が空白の場合のみ。
+    /// </summary>
+    /// <remarks>任意項目</remarks>
+    [Index(12)]
+    [TypeConverter(typeof(NumberTypeConverter<decimal?>), 10)]
+    public decimal? 顧客コード2 { get; set; }
 
     /// <summary>
     /// 振込指定区分 (N(1))  
     /// 7: テレ振込, 8: 文書振込
     /// </summary>
     /// <remarks>任意項目</remarks>
-    [Index(12)]
+    [Index(13)]
     [TypeConverter(typeof(NumberTypeConverter<int?>), 1)]
     public int? 振込指定区分 { get; set; }
 
@@ -126,7 +134,7 @@ public partial class 総合振込WriteData1 : IRecord
     /// 本欄に「Y」表示を付した場合は、「EDI情報」を含む。 
     /// </summary>
     /// <remarks>任意項目</remarks>
-    [Index(13)]
+    [Index(14)]
     [BooleanTrueValues("Y")]
     [BooleanFalseValues(" ")]
     public bool 識別表示 { get; set; }
@@ -135,7 +143,7 @@ public partial class 総合振込WriteData1 : IRecord
     /// ダミー (C(7))  
     /// スペース
     /// </summary>
-    [Index(14)]
+    [Index(15)]
     [TypeConverter(typeof(CharacterTypeConverter), 7)]
     public string ダミー { get; set; } = "";
 }

--- a/Diva.Zengin/ZenginReaderCore.cs
+++ b/Diva.Zengin/ZenginReaderCore.cs
@@ -2,7 +2,11 @@ using System.Globalization;
 using System.Text;
 using CsvHelper;
 using CsvHelper.Configuration;
-using Diva.Zengin.Formats;
+using Diva.Zengin.Configuration;
+using Diva.Zengin.Records;
+using 総合振込Data = Diva.Zengin.Records.総合振込Data;
+using 総合振込WriteData1 = Diva.Zengin.Records.総合振込WriteData1;
+using 総合振込WriteData2 = Diva.Zengin.Records.総合振込WriteData2;
 
 namespace Diva.Zengin;
 
@@ -31,7 +35,7 @@ internal class ZenginReaderCore<TSequence, THeader, TData, TTrailer, TEnd>
         _stream = stream ?? throw new ArgumentNullException(nameof(stream));
     }
 
-    public async Task<List<TSequence>> ReadAsync(FileFormat format)
+    public async Task<List<TSequence>> ReadAsync(ZenginConfiguration config)
     {
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         var encoding = Encoding.GetEncoding("shift_jis");
@@ -56,7 +60,7 @@ internal class ZenginReaderCore<TSequence, THeader, TData, TTrailer, TEnd>
 
         try
         {
-            if (format == FileFormat.Zengin)
+            if (config.FileFormat == FileFormat.Zengin)
             {
                 // When format is Zengin, convert to CSV first
                 using var zenginReader = new StreamReader(streamToUse, encoding, leaveOpen: streamToClose == null);

--- a/Diva.Zengin/ZenginWriter.cs
+++ b/Diva.Zengin/ZenginWriter.cs
@@ -1,4 +1,17 @@
-using Diva.Zengin.Formats;
+using Diva.Zengin.Configuration;
+using Diva.Zengin.Records;
+using 入出金取引明細Data1 = Diva.Zengin.Records.入出金取引明細Data1;
+using 入出金取引明細End = Diva.Zengin.Records.入出金取引明細End;
+using 入出金取引明細Header = Diva.Zengin.Records.入出金取引明細Header;
+using 入出金取引明細Trailer = Diva.Zengin.Records.入出金取引明細Trailer;
+using 振込入金通知DataA = Diva.Zengin.Records.振込入金通知DataA;
+using 振込入金通知End = Diva.Zengin.Records.振込入金通知End;
+using 振込入金通知Header = Diva.Zengin.Records.振込入金通知Header;
+using 振込入金通知Trailer = Diva.Zengin.Records.振込入金通知Trailer;
+using 総合振込Data = Diva.Zengin.Records.総合振込Data;
+using 総合振込End = Diva.Zengin.Records.総合振込End;
+using 総合振込Header = Diva.Zengin.Records.総合振込Header;
+using 総合振込Trailer = Diva.Zengin.Records.総合振込Trailer;
 
 namespace Diva.Zengin;
 
@@ -6,6 +19,7 @@ public class ZenginWriter<T>
 {
     private readonly string? _path;
     private readonly Stream? _stream;
+    private readonly ZenginConfiguration? _config;
 
     public ZenginWriter(string path)
     {
@@ -16,8 +30,20 @@ public class ZenginWriter<T>
     {
         _stream = stream ?? throw new ArgumentNullException(nameof(stream));
     }
+    
+    public ZenginWriter(string path, ZenginConfiguration config)
+    {
+        _path = path ?? throw new ArgumentNullException(nameof(path));
+        _config = config ?? throw new ArgumentNullException(nameof(config));
+    }
 
-    public async Task WriteAsync(T input, FileFormat format = FileFormat.Csv)
+    public ZenginWriter(Stream stream, ZenginConfiguration config)
+    {
+        _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+        _config = config ?? throw new ArgumentNullException(nameof(config));
+    }
+    
+    public async Task WriteAsync(T input)
     {
         if (_path == null && _stream == null)
             throw new InvalidOperationException("Both path and stream cannot be null.");
@@ -53,21 +79,21 @@ public class ZenginWriter<T>
         if (sequenceType == typeof(振込入金通知A))
         {
             await CreateWriter<振込入金通知A, 振込入金通知Header, 振込入金通知DataA, 振込入金通知Trailer, 振込入金通知End>(
-                _path, _stream, format, sequences.Cast<振込入金通知A>().ToList());
+                _path, _stream, _config, sequences.Cast<振込入金通知A>().ToList());
             return;
         }
 
         if (sequenceType == typeof(入出金取引明細1))
         {
             await CreateWriter<入出金取引明細1, 入出金取引明細Header, 入出金取引明細Data1, 入出金取引明細Trailer, 入出金取引明細End>(
-                _path, _stream, format, sequences.Cast<入出金取引明細1>().ToList());
+                _path, _stream, _config, sequences.Cast<入出金取引明細1>().ToList());
             return;
         }
 
         if (sequenceType == typeof(総合振込))
         {
             await CreateWriter<総合振込, 総合振込Header, 総合振込Data, 総合振込Trailer, 総合振込End>(
-                _path, _stream, format, sequences.Cast<総合振込>().ToList());
+                _path, _stream, _config, sequences.Cast<総合振込>().ToList());
             return;
         }
 
@@ -75,7 +101,7 @@ public class ZenginWriter<T>
     }
 
     private static async Task CreateWriter<TSequence, THeader, TData, TTrailer, TEnd>(
-        string? path, Stream? stream, FileFormat format, List<TSequence> sequences)
+        string? path, Stream? stream, ZenginConfiguration? config, List<TSequence> sequences)
         where TSequence : ISequence<THeader, TData, TTrailer, TEnd>, new()
         where THeader : IRecord, new()
         where TData : IRecord, new()
@@ -86,6 +112,7 @@ public class ZenginWriter<T>
             ? new ZenginWriterCore<TSequence, THeader, TData, TTrailer, TEnd>(stream)
             : new ZenginWriterCore<TSequence, THeader, TData, TTrailer, TEnd>(path!);
 
-        await writer.WriteAsync(sequences, format).ConfigureAwait(false);
+        config ??= new ZenginConfiguration();
+        await writer.WriteAsync(sequences, config).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
This pull request includes a comprehensive refactoring of the `Diva.Zengin` codebase, primarily focused on reorganizing namespaces and updating related configurations. The changes aim to improve code organization and clarity by moving several classes and interfaces to more appropriate namespaces and updating their usage throughout the project.

### Namespace Reorganization:

* Moved the `IIndexToLengthMap` interface from `Diva.Zengin.Formats` to `Diva.Zengin` (`Diva.Zengin.SourceGenerator/IndexToLengthMapGenerator.cs`).
* Renamed and moved the `FileFormat` enum from `Diva.Zengin.Formats` to `Diva.Zengin.Configuration` (`Diva.Zengin/Configuration/FileFormat.cs`).
* Created a new `ZenginConfiguration` class in the `Diva.Zengin.Configuration` namespace to encapsulate file format configurations (`Diva.Zengin/Configuration/ZenginConfiguration.cs`).

### Code Updates:

* Updated the `WriteReadTest` class to use the new `ZenginConfiguration` class for writing and reading operations (`Diva.Zengin.Tests/WriteReadTest.cs`).
* Modified the `ReadAsync_CollectionType_ReturnsEmpty` and `ReadAsync_SingleType_ReturnsNull` methods in `ZenginReaderTest` to remove the `FileFormat` parameter (`Diva.Zengin.Tests/ZenginReaderTest.cs`) [[1]](diffhunk://#diff-8f8cb6f531d5decbdeb045493901e4046186e09c73eb8df5ccc90e2eb4b4cfa3L39-R39) [[2]](diffhunk://#diff-8f8cb6f531d5decbdeb045493901e4046186e09c73eb8df5ccc90e2eb4b4cfa3L79-R79).

### File Renames and Namespace Updates:

* Renamed and moved several record-related files from `Diva.Zengin.Formats` to `Diva.Zengin.Records`:
  * `IRecord` (`Diva.Zengin/Records/IRecord.cs`)
  * `ISequence` (`Diva.Zengin/Records/ISequence.cs`)
  * `データ区分` (`Diva.Zengin/Records/データ区分.cs`)
  * `入出金取引明細1` (`Diva.Zengin/Records/入出金取引明細1.cs`)
  * `入出金取引明細Data1` (`Diva.Zengin/Records/入出金取引明細Data1.cs`)
  * `入出金取引明細End` (`Diva.Zengin/Records/入出金取引明細End.cs`)
  * `入出金取引明細Header` (`Diva.Zengin/Records/入出金取引明細Header.cs`)
  * `入出金取引明細Trailer` (`Diva.Zengin/Records/入出金取引明細Trailer.cs`)
  * `振込入金通知A` (`Diva.Zengin/Records/振込入金通知A.cs`)
  * `振込入金通知DataA` (`Diva.Zengin/Records/振込入金通知DataA.cs`)
  * `振込入金通知End` (`Diva.Zengin/Records/振込入金通知End.cs`)
  * `振込入金通知Header` (`Diva.Zengin/Records/振込入金通知Header.cs`)