### PR TITLE
Enhance NumberConverter to handle negative values and add StringConve…

### DIFF
--- a/Diva.Zengin.Tests/Converters/NumberConverterTest.cs
+++ b/Diva.Zengin.Tests/Converters/NumberConverterTest.cs
@@ -70,4 +70,32 @@ public class NumberConverterTest
         Assert.Equal("123", NumberConverter.ConvertToString(123, 3));
         Assert.Equal("0456", NumberConverter.ConvertToString(456, 4));
     }
+    
+    [Fact]
+    public void ConvertToString_NegativeIntegerValue_RemovesNegativeSign()
+    {
+        Assert.Equal("123", NumberConverter.ConvertToString(-123, 3));
+        Assert.Equal("0456", NumberConverter.ConvertToString(-456, 4));
+    }
+
+    [Fact]
+    public void ConvertToString_NegativeDecimalValue_RemovesNegativeSignAndDecimalPoint()
+    {
+        Assert.Equal("123", NumberConverter.ConvertToString(-123m, 3));
+        Assert.Equal("0123", NumberConverter.ConvertToString(-123m, 4));
+    }
+
+    [Fact]
+    public void ConvertToString_IntegerValue_TrimsToCount()
+    {
+        Assert.Equal("234", NumberConverter.ConvertToString(1234, 3));
+        Assert.Equal("3456", NumberConverter.ConvertToString(123456, 4));
+    }
+
+    [Fact]
+    public void ConvertToString_DecimalValue_TrimsToCount()
+    {
+        Assert.Equal("234", NumberConverter.ConvertToString(1234m, 3));
+        Assert.Equal("3456", NumberConverter.ConvertToString(123456m, 4));
+    }
 }

--- a/Diva.Zengin.Tests/Helpers/StringConverterTest.cs
+++ b/Diva.Zengin.Tests/Helpers/StringConverterTest.cs
@@ -1,0 +1,60 @@
+using System.Text;
+using Diva.Zengin.Helpers;
+using JetBrains.Annotations;
+using Xunit;
+
+namespace Diva.Zengin.Tests.Helpers;
+
+[TestSubject(typeof(StringConverter))]
+public class StringConverterTest
+{
+    [Theory]
+    [InlineData("0123456789", "0123456789")]
+    [InlineData("ABCXYZ", "ABCXYZ")]
+    [InlineData("abcxyz", "ABCXYZ")]
+    [InlineData("０１２３４５６７８９", "0123456789")]
+    [InlineData("ＡＢＣＸＹＺ", "ABCXYZ")]
+    [InlineData("ａｂｃｘｙｚ", "ABCXYZ")]
+    [InlineData("あいうえおわゐゑをんゔ", "ｱｲｳｴｵﾜｲｴｦﾝｳﾞ")]
+    [InlineData("ぁぃぅぇぉっゃゅょゎゕゖ", "ｱｲｳｴｵﾂﾔﾕﾖﾜｶｹ")]
+    [InlineData("ァィゥェォッャュョヮヵヶ", "ｱｲｳｴｵﾂﾔﾕﾖﾜｶｹ")]
+    [InlineData("ガギグゲゴパピプペポ", "ｶﾞｷﾞｸﾞｹﾞｺﾞﾊﾟﾋﾟﾌﾟﾍﾟﾎﾟ")]
+    [InlineData("（）＋，－．／：？￥¥", @"()+,-./:?\\")]
+    [InlineData("「」", "｢｣")]
+    [InlineData("　\t", "  ")]
+    public void ToHalfWidth_ShouldConvertCorrectly(string input, string expected)
+    {
+        // Act
+        var result = StringConverter.ToHalfWidth(input);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("ガギグゲゴパピプペポ", "ｶﾞｷﾞｸﾞｹﾞｺﾞﾊﾟﾋﾟﾌﾟﾍﾟﾎﾟ", NormalizationForm.FormC)]
+    [InlineData("ガギグゲゴパピプペポ", "ｶﾞｷﾞｸﾞｹﾞｺﾞﾊﾟﾋﾟﾌﾟﾍﾟﾎﾟ", NormalizationForm.FormD)]
+    [InlineData("ガギグゲゴパピプペポ", "ｶﾞｷﾞｸﾞｹﾞｺﾞﾊﾟﾋﾟﾌﾟﾍﾟﾎﾟ", NormalizationForm.FormKC)]
+    [InlineData("ガギグゲゴパピプペポ", "ｶﾞｷﾞｸﾞｹﾞｺﾞﾊﾟﾋﾟﾌﾟﾍﾟﾎﾟ", NormalizationForm.FormKD)]
+    public void ToHalfWidth_ShouldNormalizeAndConvertCorrectly(string input, string expected, NormalizationForm form)
+    {
+        // Arrange
+        var normalizedInput = input.Normalize(form);
+
+        // Act
+        var result = StringConverter.ToHalfWidth(normalizedInput);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ToHalfWidth_ShouldHandleNullInput()
+    {
+        // Act
+        var result = StringConverter.ToHalfWidth(null);
+
+        // Assert
+        Assert.Null(result);
+    }
+}

--- a/Diva.Zengin/Converters/NumberConverter.cs
+++ b/Diva.Zengin/Converters/NumberConverter.cs
@@ -39,11 +39,26 @@ internal static class NumberConverter
             return Convert.ToInt32(value).ToString($"D{count}", CultureInfo.InvariantCulture);
         }
         
-        if (value is decimal decimalValue)
+        switch (value)
         {
-            return decimalValue.ToString(new string('0', count), CultureInfo.InvariantCulture);
+            case decimal decimalValue:
+            {
+                if (decimalValue < 0)
+                    decimalValue = -decimalValue; // remove negative sign
+                var result =  decimalValue.ToString(new string('0', count), CultureInfo.InvariantCulture);
+                // trimming
+                return result.Length > count ? result[^count..] : result;
+            }
+            case int intValue:
+            {
+                if (intValue < 0)
+                    intValue = -intValue; // remove negative sign
+                var result = intValue.ToString($"D{count}", CultureInfo.InvariantCulture);
+                // trimming
+                return result.Length > count ? result[^count..] : result;
+            }
+            default:
+                return ((IFormattable)value).ToString($"D{count}", CultureInfo.InvariantCulture);
         }
-
-        return ((IFormattable)value).ToString($"D{count}", CultureInfo.InvariantCulture);
     }
 }

--- a/Diva.Zengin/Helpers/StringConverter.cs
+++ b/Diva.Zengin/Helpers/StringConverter.cs
@@ -1,0 +1,161 @@
+using System.Text;
+
+namespace Diva.Zengin.Helpers;
+
+public static class StringConverter
+{
+    public static string? ToHalfWidth(this string? input)
+    {
+        if (input == null)
+            return null;
+
+        var normalized = input.Normalize(NormalizationForm.FormKD);
+        var sb = new StringBuilder();
+
+        foreach (var n in normalized)
+        {
+            var c = n;
+
+            if (c is >= 'ぁ' and <= 'ゖ')
+            {
+                // Convert Hiragana to Katakana
+                c = (char)(c + 0x60);
+            }
+
+            switch (c)
+            {
+                case '\'' or '(' or ')' or '+' or ',' or '-' or '.' or '/' or ':' or '?' or '\\':
+                case >= 'A' and <= 'Z':
+                case >= '0' and <= '9':
+                case >= '｢' and <= '｣':
+                case >= 'ｦ' and <= 'ﾟ':
+                    sb.Append(c);
+                    break;
+                case >= 'ァ' and <= 'ヶ':
+                    sb.Append(ConvertHalfKatakana(c));
+                    break;
+                case '\u309B':
+                case '\u3099':
+                    // 濁点
+                    sb.Append('ﾞ');
+                    break;
+                case '\u309C':
+                case '\u309A':
+                    // 半濁点
+                    sb.Append('ﾟ');
+                    break;
+                case >= 'a' and <= 'z':
+                    sb.Append((char)(c - 'a' + 'A'));
+                    break;
+                case >= 'Ａ' and <= 'Ｚ':
+                    sb.Append((char)(c - 'Ａ' + 'A'));
+                    break;
+                case >= 'ａ' and <= 'ｚ':
+                    sb.Append((char)(c - 'ａ' + 'A'));
+                    break;
+                case >= '０' and <= '９':
+                    sb.Append((char)(c - '０' + '0'));
+                    break;
+                case '＇' or '（' or '）' or '＋' or '，' or '－' or '．' or '／' or '：' or '？' or '￥' or '¥': // Normalize で '￥'　にはならない
+                case '「' or '」':
+                    sb.Append(ConvertHalfWidthSymbol(c));
+                    break;
+                default:
+                    // その他
+                    sb.Append(' ');
+                    break;
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static char ConvertHalfKatakana(char c)
+    {
+        return c switch
+        {
+            'ア' => 'ｱ',
+            'イ' => 'ｲ',
+            'ウ' => 'ｳ',
+            'エ' => 'ｴ',
+            'オ' => 'ｵ',
+            'カ' => 'ｶ',
+            'キ' => 'ｷ',
+            'ク' => 'ｸ',
+            'ケ' => 'ｹ',
+            'コ' => 'ｺ',
+            'サ' => 'ｻ',
+            'シ' => 'ｼ',
+            'ス' => 'ｽ',
+            'セ' => 'ｾ',
+            'ソ' => 'ｿ',
+            'タ' => 'ﾀ',
+            'チ' => 'ﾁ',
+            'ツ' => 'ﾂ',
+            'テ' => 'ﾃ',
+            'ト' => 'ﾄ',
+            'ナ' => 'ﾅ',
+            'ニ' => 'ﾆ',
+            'ヌ' => 'ﾇ',
+            'ネ' => 'ﾈ',
+            'ノ' => 'ﾉ',
+            'ハ' => 'ﾊ',
+            'ヒ' => 'ﾋ',
+            'フ' => 'ﾌ',
+            'ヘ' => 'ﾍ',
+            'ホ' => 'ﾎ',
+            'マ' => 'ﾏ',
+            'ミ' => 'ﾐ',
+            'ム' => 'ﾑ',
+            'メ' => 'ﾒ',
+            'モ' => 'ﾓ',
+            'ヤ' => 'ﾔ',
+            'ユ' => 'ﾕ',
+            'ヨ' => 'ﾖ',
+            'ラ' => 'ﾗ',
+            'リ' => 'ﾘ',
+            'ル' => 'ﾙ',
+            'レ' => 'ﾚ',
+            'ロ' => 'ﾛ',
+            'ワ' => 'ﾜ',
+            'ヲ' => 'ｦ',
+            'ン' => 'ﾝ',
+            'ァ' => 'ｱ',
+            'ィ' => 'ｲ',
+            'ゥ' => 'ｳ',
+            'ェ' => 'ｴ',
+            'ォ' => 'ｵ',
+            'ャ' => 'ﾔ',
+            'ュ' => 'ﾕ',
+            'ョ' => 'ﾖ',
+            'ッ' => 'ﾂ',
+            'ヮ' => 'ﾜ',
+            'ヵ' => 'ｶ',
+            'ヶ' => 'ｹ',
+            'ヰ' => 'ｲ',
+            'ヱ' => 'ｴ',
+            _ => c
+        };
+    }
+
+    private static char ConvertHalfWidthSymbol(char c)
+    {
+        return c switch
+        {
+            '（' => '(',
+            '）' => ')',
+            '＋' => '+',
+            '，' => ',',
+            '－' => '-',
+            '．' => '.',
+            '／' => '/',
+            '：' => ':',
+            '？' => '?',
+            '￥' => '\\',
+            '¥' => '\\',
+            '「' => '｢',
+            '」' => '｣',
+            _ => c
+        };
+    }
+}


### PR DESCRIPTION
…rter for half-width conversion
This pull request introduces several new tests and refactors existing methods to improve functionality and coverage in the `Diva.Zengin` project. The changes include adding new test cases, creating a new helper class, and modifying the `NumberConverter` class to handle edge cases and improve code readability.

### New Tests and Helper Class:

* [`Diva.Zengin.Tests/Converters/NumberConverterTest.cs`](diffhunk://#diff-dd8d6f5163dec8bd85c25af16cae0390cb590774439144cecf115df070cd144bR73-R100): Added new test cases to cover negative integer and decimal values, and to ensure values are trimmed correctly.
* [`Diva.Zengin.Tests/Helpers/StringConverterTest.cs`](diffhunk://#diff-544fae890803a2eb1164b3dfe41ce85aa35eeab48240d0a92181370b9ceb3afeR1-R60): Introduced a new test class for `StringConverter`, including tests for converting full-width characters to half-width and handling normalization forms.

### Refactoring and Enhancements:

* [`Diva.Zengin/Converters/NumberConverter.cs`](diffhunk://#diff-e1ca0640fe34c0e3bd8c73bfac85439af853f868de088cc7b637c00384857f2dL42-R64): Refactored the `ConvertToString` method to use a `switch` statement, added handling for negative values, and ensured the result is trimmed to the specified count.

### New Helper Class:

* [`Diva.Zengin/Helpers/StringConverter.cs`](diffhunk://#diff-253dc030fa93bba94d3cb04d22276df627a4909a91465d6f8a4b1a7ad3d32e65R1-R161): Added a new static class `StringConverter` to handle the conversion of full-width characters to half-width, including special handling for Hiragana to Katakana conversion and normalization.