### PR TITLE
Add support for long vowel mark conversion to minus in StringConverter

### DIFF
--- a/Diva.Zengin.Tests/Helpers/StringConverterTest.cs
+++ b/Diva.Zengin.Tests/Helpers/StringConverterTest.cs
@@ -19,6 +19,7 @@ public class StringConverterTest
     [InlineData("ぁぃぅぇぉっゃゅょゎゕゖ", "ｱｲｳｴｵﾂﾔﾕﾖﾜｶｹ")]
     [InlineData("ァィゥェォッャュョヮヵヶ", "ｱｲｳｴｵﾂﾔﾕﾖﾜｶｹ")]
     [InlineData("ガギグゲゴパピプペポ", "ｶﾞｷﾞｸﾞｹﾞｺﾞﾊﾟﾋﾟﾌﾟﾍﾟﾎﾟ")]
+    [InlineData("ー", "-")]
     [InlineData("（）＋，－．／：？￥¥", @"()+,-./:?\\")]
     [InlineData("「」", "｢｣")]
     [InlineData("　\t", "  ")]

--- a/Diva.Zengin/Helpers/StringConverter.cs
+++ b/Diva.Zengin/Helpers/StringConverter.cs
@@ -34,6 +34,10 @@ public static class StringConverter
                 case >= 'ァ' and <= 'ヶ':
                     sb.Append(ConvertHalfKatakana(c));
                     break;
+                case 'ー': 
+                    // 長音→マイナス
+                    sb.Append('-');
+                    break;
                 case '\u309B':
                 case '\u3099':
                     // 濁点


### PR DESCRIPTION
This pull request includes changes to the `StringConverter` class and its corresponding test class to handle the conversion of the 'ー' character to a minus sign ('-').

### Changes to character conversion:

* [`Diva.Zengin/Helpers/StringConverter.cs`](diffhunk://#diff-253dc030fa93bba94d3cb04d22276df627a4909a91465d6f8a4b1a7ad3d32e65R37-R40): Added a case to handle the conversion of the 'ー' character to a minus sign ('-').

### Updates to unit tests:

* [`Diva.Zengin.Tests/Helpers/StringConverterTest.cs`](diffhunk://#diff-544fae890803a2eb1164b3dfe41ce85aa35eeab48240d0a92181370b9ceb3afeR22): Added a new test case to verify that the 'ー' character is correctly converted to a minus sign ('-').