### PR TITLE
Bump version to 1.2.3 and refactor StringConverter namespace

### DIFF
--- a/Diva.Zengin.Converters/Diva.Zengin.Converters.csproj
+++ b/Diva.Zengin.Converters/Diva.Zengin.Converters.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <PackageId>Diva.Zengin.Converters</PackageId>
+        <Version>1.0.0</Version>
+        <Authors>DIVA Co., Ltd.</Authors>
+        <Company>DIVA Co., Ltd.</Company>
+        <PackageDescription></PackageDescription>
+        <RepositoryUrl>https://github.com/diva-osaka/Diva.Zengin</RepositoryUrl>
+        <DebugType>embedded</DebugType>
+    </PropertyGroup>
+
+</Project>

--- a/Diva.Zengin.Converters/StringConverter.cs
+++ b/Diva.Zengin.Converters/StringConverter.cs
@@ -1,9 +1,15 @@
 using System.Text;
 
-namespace Diva.Zengin.Helpers;
+namespace Diva.Zengin.Converters;
 
 public static class StringConverter
 {
+    /// <summary>
+    /// 全角文字を半角文字に変換。
+    /// </summary>
+    /// <param name="input"></param>
+    /// <returns></returns>
+    /// <remarks>「付録1. 使用文字一覧」のみに変換し、変換できない文字は半角スペースに変換する。</remarks>
     public static string? ToHalfWidth(this string? input)
     {
         if (input == null)

--- a/Diva.Zengin.Tests/Converters/StringConverterTest.cs
+++ b/Diva.Zengin.Tests/Converters/StringConverterTest.cs
@@ -3,7 +3,7 @@ using Diva.Zengin.Converters;
 using JetBrains.Annotations;
 using Xunit;
 
-namespace Diva.Zengin.Tests.Helpers;
+namespace Diva.Zengin.Tests.Converters;
 
 [TestSubject(typeof(StringConverter))]
 public class StringConverterTest

--- a/Diva.Zengin.Tests/Diva.Zengin.Tests.csproj
+++ b/Diva.Zengin.Tests/Diva.Zengin.Tests.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Diva.Zengin.Converters\Diva.Zengin.Converters.csproj" />
     <ProjectReference Include="..\Diva.Zengin\Diva.Zengin.csproj" />
   </ItemGroup>
   

--- a/Diva.Zengin.Tests/Helpers/StringConverterTest.cs
+++ b/Diva.Zengin.Tests/Helpers/StringConverterTest.cs
@@ -1,5 +1,5 @@
 using System.Text;
-using Diva.Zengin.Helpers;
+using Diva.Zengin.Converters;
 using JetBrains.Annotations;
 using Xunit;
 
@@ -26,7 +26,7 @@ public class StringConverterTest
     public void ToHalfWidth_ShouldConvertCorrectly(string input, string expected)
     {
         // Act
-        var result = StringConverter.ToHalfWidth(input);
+        var result = input.ToHalfWidth();
 
         // Assert
         Assert.Equal(expected, result);
@@ -43,7 +43,7 @@ public class StringConverterTest
         var normalizedInput = input.Normalize(form);
 
         // Act
-        var result = StringConverter.ToHalfWidth(normalizedInput);
+        var result = normalizedInput.ToHalfWidth();
 
         // Assert
         Assert.Equal(expected, result);

--- a/Diva.Zengin.sln
+++ b/Diva.Zengin.sln
@@ -6,6 +6,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Diva.Zengin.Tests", "Diva.Z
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Diva.Zengin.SourceGenerator", "Diva.Zengin.SourceGenerator\Diva.Zengin.SourceGenerator.csproj", "{90FBCCBF-1A47-4C60-8B76-7D739AC8DC2C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Diva.Zengin.Converters", "Diva.Zengin.Converters\Diva.Zengin.Converters.csproj", "{DFF9621A-FA81-4737-81FD-ADD1EF91F907}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +26,9 @@ Global
 		{90FBCCBF-1A47-4C60-8B76-7D739AC8DC2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{90FBCCBF-1A47-4C60-8B76-7D739AC8DC2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{90FBCCBF-1A47-4C60-8B76-7D739AC8DC2C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DFF9621A-FA81-4737-81FD-ADD1EF91F907}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DFF9621A-FA81-4737-81FD-ADD1EF91F907}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DFF9621A-FA81-4737-81FD-ADD1EF91F907}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DFF9621A-FA81-4737-81FD-ADD1EF91F907}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Diva.Zengin/Diva.Zengin.csproj
+++ b/Diva.Zengin/Diva.Zengin.csproj
@@ -5,11 +5,12 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Diva.Zengin</PackageId>
-        <Version>1.2.1</Version>
+        <Version>1.2.3</Version>
         <Authors>DIVA Co., Ltd.</Authors>
         <Company>DIVA Co., Ltd.</Company>
         <PackageDescription></PackageDescription>
         <RepositoryUrl>https://github.com/diva-osaka/Diva.Zengin</RepositoryUrl>
+        <DebugType>embedded</DebugType>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This pull request includes several changes to the `Diva.Zengin` project, focusing on the addition of a new `Diva.Zengin.Converters` project, updates to namespaces, and improvements to the test suite. Below are the most important changes:

### Addition of `Diva.Zengin.Converters` Project:

* Added a new project file `Diva.Zengin.Converters.csproj` with necessary properties and metadata.
* Updated the solution file `Diva.Zengin.sln` to include the new `Diva.Zengin.Converters` project. [[1]](diffhunk://#diff-df996291f35b6ec1e2981cb92d492395dc94003db706168b82ca0b7d63f0d67cR9-R10) [[2]](diffhunk://#diff-df996291f35b6ec1e2981cb92d492395dc94003db706168b82ca0b7d63f0d67cR29-R32)

### Namespace Updates:

* Renamed `Diva.Zengin/Helpers/StringConverter.cs` to `Diva.Zengin.Converters/StringConverter.cs` and updated the namespace from `Diva.Zengin.Helpers` to `Diva.Zengin.Converters`.

### Test Suite Improvements:

* Updated `Diva.Zengin.Tests/Diva.Zengin.Tests.csproj` to reference the new `Diva.Zengin.Converters` project.
* Modified `Diva.Zengin.Tests/Helpers/StringConverterTest.cs` to reflect the namespace change and improved the usage of the `ToHalfWidth` extension method. [[1]](diffhunk://#diff-544fae890803a2eb1164b3dfe41ce85aa35eeab48240d0a92181370b9ceb3afeL2-R2) [[2]](diffhunk://#diff-544fae890803a2eb1164b3dfe41ce85aa35eeab48240d0a92181370b9ceb3afeL29-R29) [[3]](diffhunk://#diff-544fae890803a2eb1164b3dfe41ce85aa35eeab48240d0a92181370b9ceb3afeL46-R46)

### Miscellaneous:

* Updated the version in `Diva.Zengin/Diva.Zengin.csproj` from `1.2.1` to `1.2.3` and added the `DebugType` property.