### PR TITLE
Rename namespace

### DIFF
--- a/Diva.Zengin.Helpers/Diva.Zengin.Helpers.csproj
+++ b/Diva.Zengin.Helpers/Diva.Zengin.Helpers.csproj
@@ -4,13 +4,14 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
-        <PackageId>Diva.Zengin.Converters</PackageId>
-        <Version>1.0.0</Version>
+        <PackageId>Diva.Zengin.Helpers</PackageId>
+        <Version>1.0.1</Version>
         <Authors>DIVA Co., Ltd.</Authors>
         <Company>DIVA Co., Ltd.</Company>
         <PackageDescription></PackageDescription>
         <RepositoryUrl>https://github.com/diva-osaka/Diva.Zengin</RepositoryUrl>
         <DebugType>embedded</DebugType>
+        <RootNamespace>Diva.Zengin.Helpers</RootNamespace>
     </PropertyGroup>
 
 </Project>

--- a/Diva.Zengin.Helpers/StringConverter.cs
+++ b/Diva.Zengin.Helpers/StringConverter.cs
@@ -1,6 +1,6 @@
 using System.Text;
 
-namespace Diva.Zengin.Converters;
+namespace Diva.Zengin.Helpers;
 
 public static class StringConverter
 {

--- a/Diva.Zengin.Tests/Diva.Zengin.Tests.csproj
+++ b/Diva.Zengin.Tests/Diva.Zengin.Tests.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Diva.Zengin.Converters\Diva.Zengin.Converters.csproj" />
+    <ProjectReference Include="..\Diva.Zengin.Helpers\Diva.Zengin.Helpers.csproj" />
     <ProjectReference Include="..\Diva.Zengin\Diva.Zengin.csproj" />
   </ItemGroup>
   

--- a/Diva.Zengin.Tests/Helpers/StringConverterTest.cs
+++ b/Diva.Zengin.Tests/Helpers/StringConverterTest.cs
@@ -1,9 +1,9 @@
 using System.Text;
-using Diva.Zengin.Converters;
+using Diva.Zengin.Helpers;
 using JetBrains.Annotations;
 using Xunit;
 
-namespace Diva.Zengin.Tests.Converters;
+namespace Diva.Zengin.Tests.Helpers;
 
 [TestSubject(typeof(StringConverter))]
 public class StringConverterTest

--- a/Diva.Zengin.sln
+++ b/Diva.Zengin.sln
@@ -6,7 +6,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Diva.Zengin.Tests", "Diva.Z
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Diva.Zengin.SourceGenerator", "Diva.Zengin.SourceGenerator\Diva.Zengin.SourceGenerator.csproj", "{90FBCCBF-1A47-4C60-8B76-7D739AC8DC2C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Diva.Zengin.Converters", "Diva.Zengin.Converters\Diva.Zengin.Converters.csproj", "{DFF9621A-FA81-4737-81FD-ADD1EF91F907}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Diva.Zengin.Helpers", "Diva.Zengin.Helpers\Diva.Zengin.Helpers.csproj", "{DFF9621A-FA81-4737-81FD-ADD1EF91F907}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Diva.Zengin/Diva.Zengin.csproj
+++ b/Diva.Zengin/Diva.Zengin.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Diva.Zengin</PackageId>
-        <Version>1.2.3</Version>
+        <Version>1.2.4</Version>
         <Authors>DIVA Co., Ltd.</Authors>
         <Company>DIVA Co., Ltd.</Company>
         <PackageDescription></PackageDescription>


### PR DESCRIPTION
日本語で返答すること

This pull request involves renaming the `Diva.Zengin.Converters` project to `Diva.Zengin.Helpers` and updating the corresponding references throughout the codebase. The most important changes include updating project files, namespaces, and references in test files.

Project renaming and updates:

* [`Diva.Zengin.Helpers/Diva.Zengin.Helpers.csproj`](diffhunk://#diff-a0f7fea5683a6054a42304d6a62a187973f3afaa96202b5ab0a96d2545851d07L7-R14): Renamed from `Diva.Zengin.Converters/Diva.Zengin.Converters.csproj`, updated `PackageId` to `Diva.Zengin.Helpers`, and incremented the version to `1.0.1`. Added `RootNamespace` as `Diva.Zengin.Helpers`.
* [`Diva.Zengin.Tests/Diva.Zengin.Tests.csproj`](diffhunk://#diff-a9536ab2edce6f4edfe3f4664c5b81f9753ed2d6a13055ad4ae75da393336614L23-R23): Updated the project reference to point to the renamed `Diva.Zengin.Helpers` project.
* [`Diva.Zengin.sln`](diffhunk://#diff-df996291f35b6ec1e2981cb92d492395dc94003db706168b82ca0b7d63f0d67cL9-R9): Updated the solution file to reflect the renamed project from `Diva.Zengin.Converters` to `Diva.Zengin.Helpers`.

Namespace updates:

* [`Diva.Zengin.Helpers/StringConverter.cs`](diffhunk://#diff-33bb197c66dc599584d811745ed5c1ecd8752721f52895f95921c465f161f3abL3-R3): Renamed from `Diva.Zengin.Converters/StringConverter.cs` and updated the namespace to `Diva.Zengin.Helpers`.
* [`Diva.Zengin.Tests/Helpers/StringConverterTest.cs`](diffhunk://#diff-544fae890803a2eb1164b3dfe41ce85aa35eeab48240d0a92181370b9ceb3afeL2-R6): Renamed from `Diva.Zengin.Tests/Converters/StringConverterTest.cs` and updated the namespace to `Diva.Zengin.Tests.Helpers`.

Version increment:

* [`Diva.Zengin/Diva.Zengin.csproj`](diffhunk://#diff-100b38cbe7c5d1e4989d93e4debf1f31ccf145e0c21711ebbb657529be26f5d8L8-R8): Incremented the version from `1.2.3` to `1.2.4`.