### PR TITLE
Update package references to latest versions

### DIFF
--- a/Diva.Zengin.SourceGenerator/Diva.Zengin.SourceGenerator.csproj
+++ b/Diva.Zengin.SourceGenerator/Diva.Zengin.SourceGenerator.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     </ItemGroup>
 
 </Project>

--- a/Diva.Zengin.SourceGenerator/Diva.Zengin.SourceGenerator.csproj
+++ b/Diva.Zengin.SourceGenerator/Diva.Zengin.SourceGenerator.csproj
@@ -10,7 +10,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0">
+        <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/Diva.Zengin.Tests/Diva.Zengin.Tests.csproj
+++ b/Diva.Zengin.Tests/Diva.Zengin.Tests.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="35.6.2" />
+    <PackageReference Include="Bogus" Version="35.6.3" />
     <PackageReference Include="JetBrains.Annotations" Version="2025.1.0-eap1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Diva.Zengin/Diva.Zengin.csproj
+++ b/Diva.Zengin/Diva.Zengin.csproj
@@ -15,7 +15,7 @@
 
     <ItemGroup>
       <PackageReference Include="CsvHelper" Version="33.0.1" />
-      <PackageReference Include="Riok.Mapperly" Version="4.1.1">
+      <PackageReference Include="Riok.Mapperly" Version="4.2.1">
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>
     </ItemGroup>


### PR DESCRIPTION
This pull request updates several package dependencies across the project to their latest versions, ensuring compatibility and access to new features and fixes.

### Dependency Updates:

* [`Diva.Zengin.SourceGenerator/Diva.Zengin.SourceGenerator.csproj`](diffhunk://#diff-80b5cd98174bc207afbaf480741bb0f5de41568192f7ac480f147b8b85ffee4fL13-R13): Updated `Microsoft.CodeAnalysis.CSharp` package from version `4.13.0` to `4.14.0`.
* `Diva.Zengin.Tests/Diva.Zengin.Tests.csproj`: 
  - Updated `Bogus` package from version `35.6.2` to `35.6.3`.
  - Updated `xunit.runner.visualstudio` package from version `3.0.2` to `3.1.0`.
* [`Diva.Zengin/Diva.Zengin.csproj`](diffhunk://#diff-100b38cbe7c5d1e4989d93e4debf1f31ccf145e0c21711ebbb657529be26f5d8L18-R18): Updated `Riok.Mapperly` package from version `4.1.1` to `4.2.1`.